### PR TITLE
Add i18n Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - if [ ! -z "$GPG_SECRET_KEYS" ]; then echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import; fi
   - if [ ! -z "$GPG_OWNERTRUST" ]; then echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust; fi
 install:
-  - mvn clean --settings .travis/settings.xml install -DskipTests=true -Dmaven.javadoc.skip=true -Dgpg.skip -B -V
+  - mvn clean --settings .travis/settings.xml install -Dmaven.javadoc.skip=true -Dgpg.skip -B -V
 script:
   - mvn org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar -Dsonar.login=$SONAR_TOKEN
 deploy:

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,12 @@
       <version>1.7.22</version>
       <type>jar</type>
     </dependency>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.12</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/ru/sbtqa/tag/qautils/i18n/I18N.java
+++ b/src/main/java/ru/sbtqa/tag/qautils/i18n/I18N.java
@@ -50,7 +50,7 @@ public class I18N extends Properties {
      * @return Resources for given class
      */
     public static final I18N getI18n(Class callerClass, String bundlePath) {
-        return getI18n(callerClass, Locale.getDefault(), "i18n");
+        return getI18n(callerClass, Locale.getDefault(), bundlePath);
     }
 
     /**
@@ -66,8 +66,8 @@ public class I18N extends Properties {
         String classPath = callerClass.getPackage().getName().replaceAll("\\.", File.separator);
         String s = File.separator;
         String resourceFile = bundlePath + s + classPath + s + className + s +
-                locale.getCountry() + ".properties";
-        LOG.info("Loading i18n bundle from {}", resourceFile);
+                locale.getLanguage() + ".properties";
+        LOG.debug("Loading i18n bundle from {}", resourceFile);
         I18N properties = new I18N();
         try (InputStream streamFromResources = I18N.class.getClassLoader().getResourceAsStream(resourceFile)) {
             InputStreamReader isr = new InputStreamReader(streamFromResources, "UTF-8");

--- a/src/main/java/ru/sbtqa/tag/qautils/i18n/I18N.java
+++ b/src/main/java/ru/sbtqa/tag/qautils/i18n/I18N.java
@@ -1,0 +1,94 @@
+package ru.sbtqa.tag.qautils.i18n;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * i18n resource bundle from utf-8 properties
+ */
+public class I18N extends Properties {
+
+    private static final Logger LOG = LoggerFactory.getLogger(I18N.class);
+
+
+    /**
+     * Gets bundle with default system locale and i18n as parent path
+     *
+     * @param callerClass Class resource for
+     * @return Resources for given class
+     */
+    public static final I18N getI18n(Class callerClass) {
+        return getI18n(callerClass, Locale.getDefault(), "i18n");
+    }
+
+    /**
+     * Gets bundle with given locale and i18n as parent path
+     *
+     * @param callerClass Class resource for
+     * @param locale Resources locale
+     * @return Resources for given class
+     */
+    public static final I18N getI18n(Class callerClass, Locale locale) {
+        return getI18n(callerClass, locale, "i18n");
+    }
+
+    /**
+     * Gets bundle with default system locale and given parent path
+     *
+     * @param callerClass Class resource for
+     * @param bundlePath Resources parent path
+     * @return Resources for given class
+     */
+    public static final I18N getI18n(Class callerClass, String bundlePath) {
+        return getI18n(callerClass, Locale.getDefault(), "i18n");
+    }
+
+    /**
+     * Gets bundle with given locale and parent path
+     *
+     * @param callerClass Class resource for
+     * @param locale Resources locale
+     * @param bundlePath Resources parent path
+     * @return Resources for given class
+     */
+    public static final I18N getI18n(Class callerClass, Locale locale, String bundlePath) {
+        String className = callerClass.getSimpleName();
+        String classPath = callerClass.getPackage().getName().replaceAll("\\.", File.separator);
+        String s = File.separator;
+        String resourceFile = bundlePath + s + classPath + s + className + s +
+                locale.getCountry() + ".properties";
+        LOG.info("Loading i18n bundle from {}", resourceFile);
+        I18N properties = new I18N();
+        try (InputStream streamFromResources = I18N.class.getClassLoader().getResourceAsStream(resourceFile)) {
+            InputStreamReader isr = new InputStreamReader(streamFromResources, "UTF-8");
+            properties.load(isr);
+        } catch (IOException e) {
+            throw new I18NRuntimeException("Failed to access bundle properties file", e);
+        }
+        return properties;
+    }
+
+    /**
+     * Swap keys and values in bundle
+     *
+     * @return
+     */
+    public I18N reverse() {
+        Set<Map.Entry<Object, Object>> entries = this.entrySet();
+        I18N reversed = new I18N();
+        for (Map.Entry<Object, Object> entry : entries) {
+            reversed.put(entry.getValue(), entry.getKey());
+        }
+        return reversed;
+    }
+}

--- a/src/main/java/ru/sbtqa/tag/qautils/i18n/I18NRuntimeException.java
+++ b/src/main/java/ru/sbtqa/tag/qautils/i18n/I18NRuntimeException.java
@@ -1,0 +1,29 @@
+package ru.sbtqa.tag.qautils.i18n;
+
+public class I18NRuntimeException extends RuntimeException {
+
+    /**
+     *
+     * @param e a {@link Throwable} object.
+     */
+    public I18NRuntimeException(Throwable e) {
+        super(e);
+    }
+
+    /**
+     *
+     * @param message a {@link String} object.
+     * @param e a {@link Throwable} object.
+     */
+    public I18NRuntimeException(String message, Throwable e) {
+        super(message, e);
+    }
+
+    /**
+     *
+     * @param message a {@link String} object.
+     */
+    public I18NRuntimeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/ru/sbtqa/tag/qautils/properties/Props.java
+++ b/src/main/java/ru/sbtqa/tag/qautils/properties/Props.java
@@ -2,6 +2,7 @@ package ru.sbtqa.tag.qautils.properties;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,8 +18,9 @@ public class Props {
         String sConfigFile = System.getProperty("TagConfigFile", "config/application.properties");
         properties = new Properties();
         LOG.info("Loading properties from {}", sConfigFile);
-        try (InputStream streamFromResources = Props.class.getClassLoader().getResourceAsStream(sConfigFile);) {
-            properties.load(streamFromResources);
+        try (InputStream streamFromResources = Props.class.getClassLoader().getResourceAsStream(sConfigFile)) {
+            InputStreamReader isr = new InputStreamReader(streamFromResources, "UTF-8");
+            properties.load(isr);
         } catch (IOException e) {
             throw new PropsRuntimeException("Failed to access properties file", e);
         }

--- a/src/test/java/ru/sbtqa/tag/qautils/i18n/I18NTest.java
+++ b/src/test/java/ru/sbtqa/tag/qautils/i18n/I18NTest.java
@@ -1,0 +1,49 @@
+package ru.sbtqa.tag.qautils.i18n;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Locale;
+
+public class I18NTest {
+
+    @Test
+    public void getI18nDefaultTest() {
+        Locale.setDefault(Locale.ENGLISH);
+        I18N i18n = I18N.getI18n(I18NTest.class);
+        Assert.assertEquals("Test String", i18n.getProperty("test.string"));
+    }
+
+    @Test
+    public void getI18nLocaleTest() {
+        I18N i18n = I18N.getI18n(I18NTest.class, new Locale("ru", "RU"));
+        Assert.assertEquals("Тестовая строка", i18n.getProperty("test.string"));
+    }
+
+    @Test
+    public void getI18nCustomRootTest() {
+        Locale.setDefault(Locale.ENGLISH);
+        I18N i18n = I18N.getI18n(I18NTest.class, "i18ns");
+        Assert.assertEquals("Test Strings", i18n.getProperty("test.string.s"));
+    }
+
+    @Test
+    public void getI18nFullTest() {
+        Locale.setDefault(Locale.ENGLISH);
+        I18N i18n = I18N.getI18n(I18NTest.class, new Locale("ru", "RU"), "i18ns");
+        Assert.assertEquals("Тестовые строки", i18n.getProperty("test.string.s"));
+    }
+
+    @Test
+    public void getI18nReverseTest() {
+        I18N i18nReverse;
+        i18nReverse = new I18N();
+        i18nReverse.put("Тестовая строка", "test.string");
+        i18nReverse.put("Тестовая строка 1", "test.string.1");
+        i18nReverse.put("Тестовая строка 2", "test.string.2");
+        i18nReverse.put("Тестовая строка 3", "test.string.3");
+
+        I18N i18n = I18N.getI18n(I18NTest.class, new Locale("ru", "RU"));
+        Assert.assertEquals(i18nReverse, i18n.reverse());
+    }
+}

--- a/src/test/resources/i18n/ru/sbtqa/tag/qautils/i18n/I18NTest/en.properties
+++ b/src/test/resources/i18n/ru/sbtqa/tag/qautils/i18n/I18NTest/en.properties
@@ -1,0 +1,4 @@
+test.string=Test String
+test.string.1=Test String 1
+test.string.2=Test String 2
+test.string.3=Test String 3

--- a/src/test/resources/i18n/ru/sbtqa/tag/qautils/i18n/I18NTest/ru.properties
+++ b/src/test/resources/i18n/ru/sbtqa/tag/qautils/i18n/I18NTest/ru.properties
@@ -1,0 +1,4 @@
+test.string=Тестовая строка
+test.string.1=Тестовая строка 1
+test.string.2=Тестовая строка 2
+test.string.3=Тестовая строка 3

--- a/src/test/resources/i18ns/ru/sbtqa/tag/qautils/i18n/I18NTest/en.properties
+++ b/src/test/resources/i18ns/ru/sbtqa/tag/qautils/i18n/I18NTest/en.properties
@@ -1,0 +1,4 @@
+test.string.s=Test Strings
+test.string.s.1=Test Strings 1
+test.string.s.2=Test Strings 2
+test.string.s.3=Test Strings 3

--- a/src/test/resources/i18ns/ru/sbtqa/tag/qautils/i18n/I18NTest/ru.properties
+++ b/src/test/resources/i18ns/ru/sbtqa/tag/qautils/i18n/I18NTest/ru.properties
@@ -1,0 +1,4 @@
+test.string.s=Тестовые строки
+test.string.s.1=Тестовые строки 1
+test.string.s.2=Тестовые строки 2
+test.string.s.3=Тестовые строки 3


### PR DESCRIPTION
Created i18n util
How to use:

Create resource file like /src/main/resources/i18n/ru/sbtqa/tag/pagefactory/Page/RU.properties with content:
```
fill.the.field = заполняет поле
```


By default it gets System default locale and i18n folder as parent. Both of these params can be overridden. Reverse method is useful for annotations parsing when we know translated action title (or stepdef) and don`t know its key.

```
I18N i18n = I18N.getI18n(Page.class);
System.out.println(i18n);
System.out.println(i18n.reverse());
```

Output:
```
{fill.the.field=заполняет поле}
{заполняет поле=fill.the.field}
```

Now we can annotate actions and stepdefs with keys like fill.the.field and translate it via this util and wise versa.